### PR TITLE
Use `nn.AdaptiveAvgPool2d`  instead of  `nn.AvgPool2d`

### DIFF
--- a/model/resnet_cbam.py
+++ b/model/resnet_cbam.py
@@ -156,7 +156,7 @@ class ResNet(nn.Module):
         self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
         self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-        self.avgpool = nn.AvgPool2d(7, stride=1)
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.fc = nn.Linear(512 * block.expansion, num_classes)
 
         for m in self.modules():


### PR DESCRIPTION
Use `nn.AdaptiveAvgPool2d`  instead of  `nn.AvgPool2d` for free size input.